### PR TITLE
BMAPS-1772 Added urlGenerator to MVTSource options

### DIFF
--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -327,28 +327,10 @@ class MVTSource {
       // If the zoom has changed since the request was made, don't draw the tile
       if (this.map.getZoom() != tileContext.zoom) return;
 
-      // Get the buffer from the response
-      let buffer;
-      try {
-        const arrayBuffer = await response.arrayBuffer();
-        buffer = new Uint8Array(arrayBuffer);
-      } catch (error) {
-        console.error('Error occurred while getting arrayBuffer from response:', error);
-        return;
-      }
-
-      // Create a protobuf instance using the buffer
-      let pbf;
-      try {
-        pbf = new Pbf(buffer);
-      } catch (error) {
-        console.error('Error occurred while creating pbf instance:', error);
-        return;
-      }
-
       // Create a vector tile instance and draw it
       try {
-        const vectorTile = new VectorTile(pbf);
+        const arrayBuffer = await response.arrayBuffer();
+        const vectorTile = new VectorTile(new Pbf(new Uint8Array(arrayBuffer)));
         this._drawVectorTile(vectorTile, tileContext);
       } catch (error) {
         console.error('Error occurred while creating/drawing vector tile:', error);

--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -308,8 +308,8 @@ class MVTSource {
 
     // Create the source url with the urlGenerator function if it exists, else replace {z} {y} and {x}
     let src;
-    if (this.urlGenerator) {
-      src = this.urlGenerator(tile.zoom, tile.x, tile.y);
+    if (this._urlGenerator) {
+      src = this._urlGenerator(tile.zoom, tile.x, tile.y);
     } else {
       src = this._url.replace('{z}', tile.zoom).replace('{x}', tile.x).replace('{y}', tile.y);
     }


### PR DESCRIPTION
## Issue Link
<!-- Be sure to add the issue key in the pull request title so it will automatically transition upon merge. ex. BMAPS-123-->
[BMAPS-1772](https://northpoint-development.atlassian.net/browse/BMAPS-1772)

## Description
<!-- Concisely describe what the pull request does. -->
This pull request:
- Adds an optional urlGenerator parameter to MVTOptions
- Adds error handling when drawing vector tiles
- Moves call to draw debug info before drawing vector tile information so that debug tiles are always drawn

[BMAPS-1772]: https://northpoint-development.atlassian.net/browse/BMAPS-1772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ