### PR TITLE
BMAPS-1698 Update package.json and publish package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vector-tiles-google-maps",
-    "version": "0.0.1",
+    "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vector-tiles-google-maps",
-            "version": "0.0.1",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
                 "@mapbox/vector-tile": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
-    "name": "vector-tiles-google-maps",
-    "version": "0.0.1",
+    "name": "@northpoint-labs/vector-tiles-google-maps",
+    "version": "1.0.0",
     "author": "Jesús Barrio Pérez",
+    "main": "main.js",
     "license": "MIT",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/northpoint-development/Vector-Tiles-Google-Maps"
+    },
+    "readmeFilename": "README.md",
     "scripts": {
         "test": "NODE_OPTIONS=--experimental-vm-modules jest",
         "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Jesús Barrio Pérez",
     "main": "main.js",
     "license": "MIT",


### PR DESCRIPTION
## Issue Link
<!-- Be sure to add the issue key in the pull request title so it will automatically transition upon merge. ex. BMAPS-123-->
[BMAPS-1698](https://northpoint-development.atlassian.net/browse/BMAPS-1698)

## Description
<!-- Concisely describe what the pull request does. -->
- Updates package.json to use `northpoint-labs` organization
- Adds `main` property to package.json

## Tests
1. See that the package, when installed in BMAPS, allows for vector tiles to display

[BMAPS-1698]: https://northpoint-development.atlassian.net/browse/BMAPS-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ