### PR TITLE
BMAPS-2018 change import

### DIFF
--- a/lib/drawing.js
+++ b/lib/drawing.js
@@ -1,4 +1,4 @@
-import {getPoint} from './geometry';
+import {getPoint} from './geometry.js';
 
 /**
  * Accepts a canvas and optionally applies styles from a StyleOptions object before returning the context2d for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vector-tiles-google-maps",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vector-tiles-google-maps",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
                 "@mapbox/vector-tile": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": "Jesús Barrio Pérez",
     "main": "main.js",
     "license": "MIT",


### PR DESCRIPTION
## Issue Link
<!-- Be sure to add the issue key in the pull request title so it will automatically transition upon merge. ex. BMAPS-123-->
[BMAPS-2018](https://northpoint-development.atlassian.net/browse/BMAPS-2018)

## Description
While upgrading BMAPS to vite, I found an error where only for vector-tile-google-maps the import with a `.js` extension caused problems when running the test suite. It seemed like the simplest solution would just be to add the extension and republish the package as no other imported packages are failing like this. 

[BMAPS-2018]: https://northpoint-development.atlassian.net/browse/BMAPS-2018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ