### PR TITLE
Export draw functions

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import {MVTFeature} from './src/MVTFeature.js';
 import {MVTLayer} from './src/MVTLayer.js';
 import {getContext2d} from './lib/drawing.js';
 import {getPoint, getTileFromString, getTileString} from './lib/geometry.js';
+import {drawPoint, drawLineString, drawPolygon} from './lib/drawing.js';
 
 
 export {
@@ -13,6 +14,9 @@ export {
   MVTFeature,
   getPoint,
   getContext2d,
+  drawPoint,
+  drawLineString,
+  drawPolygon,
 
   MVTLayer,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@northpoint-labs/vector-tiles-google-maps",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "license": "MIT",
             "dependencies": {
                 "@mapbox/vector-tile": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "author": "Jesús Barrio Pérez",
     "main": "main.js",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.1.3",
+    "version": "1.1.2",
     "author": "Jesús Barrio Pérez",
     "main": "main.js",
     "license": "MIT",


### PR DESCRIPTION
I had a problem with the market/submarket layer where polygons were replaced with small dots. I found a fix that we can pass in `drawPolygon` as the `customDraw` function when making new vector tile layers. To be able to efficiently re-use code, we need to export `drawPolygon` from the package.

### Changes
- For market/submarket layer, exports draw function so we can set custom draw to always be polygon
- Updates package version