### PR TITLE
BMAPS-2448 Update package to work with fractional zooming

### DIFF
--- a/lib/mercator.js
+++ b/lib/mercator.js
@@ -55,7 +55,7 @@ const getTileAtLatLng = (latLng, zoom, tileSize=256) => {
   return {
     x: Math.floor(p.x / s),
     y: Math.floor(p.y / s),
-    z: zoom,
+    z: Math.round(zoom),
   };
 };
 
@@ -68,7 +68,7 @@ const getTileAtLatLng = (latLng, zoom, tileSize=256) => {
 const getTileBounds = (tile, tileSize=256) => {
   tile = normalizeTile(tile);
   const t = Math.pow(2, tile.z);
-  const s = tileSize / t;
+  const s = (tileSize / t);
   const sw = {
     x: tile.x * s,
     y: (tile.y * s) + s,
@@ -127,16 +127,24 @@ const fromLatLngToPixels = (map, latLng) => {
  */
 const fromLatLngToTilePoint = (map, evt, tileSize=256) => {
   const zoom = map.getZoom();
-  const tile = getTileAtLatLng(evt.latLng, zoom, tileSize);
+  const tile = getTileAtLatLng(evt.latLng, Math.round(zoom), tileSize);
   const tileBounds = getTileBounds(tile, tileSize);
   const tileSwLatLng = new google.maps.LatLng(tileBounds.sw);
   const tileNeLatLng = new google.maps.LatLng(tileBounds.ne);
   const tileSwPixels = fromLatLngToPixels(map, tileSwLatLng);
   const tileNePixels = fromLatLngToPixels(map, tileNeLatLng);
 
+  // Scale the pixel coordinates to the tile's size because the bounds may be larger or smaller than the tile's size
+  // when fractional zooming is enabled
+  const scaleX = tileSize / (tileNePixels.x - tileSwPixels.x);
+  const scaleY = tileSize / (tileNePixels.y - tileSwPixels.y);
+  const scaledX = (evt.pixel.x - tileSwPixels.x) * scaleX;
+  const scaledY = (evt.pixel.y - tileNePixels.y) * scaleY;
+
+
   return {
-    x: evt.pixel.x - tileSwPixels.x,
-    y: evt.pixel.y - tileNePixels.y,
+    x: Math.abs(scaledX),
+    y: Math.abs(scaledY),
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.1.4",
+    "version": "1.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@northpoint-labs/vector-tiles-google-maps",
-            "version": "1.1.4",
+            "version": "1.1.3",
             "license": "MIT",
             "dependencies": {
                 "@mapbox/vector-tile": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@northpoint-labs/vector-tiles-google-maps",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "license": "MIT",
             "dependencies": {
                 "@mapbox/vector-tile": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.1.4",
+    "version": "1.1.3",
     "author": "Jesús Barrio Pérez",
     "main": "main.js",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@northpoint-labs/vector-tiles-google-maps",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "author": "Jesús Barrio Pérez",
     "main": "main.js",
     "license": "MIT",

--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -97,9 +97,17 @@ class MVTFeature {
    * Redraw all the tiles that this feature is in. Used to apply styling changes
    */
   redrawTiles() {
-    const mapZoom = this.mVTSource.map.getZoom();
+    const mapZoom = Math.round(this.mVTSource.map.getZoom());
+    const mapCeilingZoom = Math.ceil(this.mVTSource.map.getZoom());
+    const mapFloorZoom = Math.floor(this.mVTSource.map.getZoom());
+
+    // Only redraw the tiles that are visible at the current zoom level
+    // At x.5 zoom levels with fractional zoom enabled, some tiles will be visible at both zoom levels
+    // so we check for both the floor and ceiling zoom levels
     Object.keys(this.tiles).forEach((tileId) => {
-      if (getTileFromString(tileId).zoom !== mapZoom) return;
+      if (getTileFromString(tileId).zoom !== mapZoom && getTileFromString(tileId).zoom !==
+          mapCeilingZoom && getTileFromString(tileId).zoom !==
+          mapFloorZoom ) return;
       this.mVTSource.redrawTile(tileId);
     });
   }

--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -343,8 +343,12 @@ class MVTSource {
     }
     if (response.ok & isCorrectContentType) {
       // If the zoom has changed since the request was made, don't draw the tile
-      if (this.map.getZoom() != tileContext.zoom) return;
-
+      // Round the zoom to the nearest whole number to avoid issues with fractional zooming
+      // If the zoom is at an x.5 zoom level, google maps retrieves tiles from both zoom levels
+      // so we check if the zoom matches the floor and ceiling of the zoom level as well
+      if (Math.round(this.map.getZoom()) != tileContext.zoom &&
+          Math.floor(this.map.getZoom()) != tileContext.zoom &&
+          Math.ceil(this.map.getZoom()) != tileContext.zoom) return;
       // Create a vector tile instance and draw it
       try {
         const arrayBuffer = await response.arrayBuffer();
@@ -483,7 +487,7 @@ class MVTSource {
    * @param {ClickHandlerOptions} options
    */
   _mouseEventContinue(event, callbackFunction = ()=>{}, options) {
-    const tile = getTileAtLatLng(event.latLng, this.map.getZoom(), this._tileSize);
+    const tile = getTileAtLatLng(event.latLng, Math.round(this.map.getZoom()), this._tileSize);
     const tileId = getTileString(tile.z, tile.x, tile.y);
     const tileContext = this._visibleTiles[tileId];
     if (!tileContext) return;
@@ -540,7 +544,7 @@ class MVTSource {
   }
 
   deselectAllFeatures() {
-    const zoom = this.map.getZoom();
+    const zoom = Math.round(this.map.getZoom());
     /** @type {Array<string>} */
     const tilesToRedraw = [];
     Object.entries(this._selectedFeatures).forEach(([featureId, mVTFeature]) => {


### PR DESCRIPTION
## Issue Link
<!-- Be sure to add the issue key in the pull request title so it will automatically transition upon merge. ex. BMAPS-123-->
[BMAPS-2448](https://northpoint-development.atlassian.net/browse/BMAPS-2448)

## Description
<!-- Concisely describe what the pull request does. -->
Previously, the package made assumptions that the map's zoom level would always be integer values.
This PR refactors some of the mercator functions, `MVTSource`, and `MVTFeature` to work with fractional zoom levels. Specifically, the zoom level needed to be rounded when making comparisons, and click events on tiles needed to be scaled to the tile size.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Pull this branch locally and run with BMAPS. 
In BMAPS pull down the remote branch `sdubbert/BMAPS-2448` where fractional zooming is enabled
Test that vector layers render correctly and features can be selected at fractional zoom levels.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
ALWAYS
- [x] My pull request title matches the following format: [project acronym]-### - [concise title]
      (Ex. 'BMAPS-123 Updated Pull Request Template')
- [ ] I added/updated tests for the changes I made. (Or I have explained why I have not)
- [x] I have run `npm audit fix` (Maybe multiple times) until all vulnerabilities that can be automatically fixed are fixed. If there are vulnerabilties that will need to be fixed manually, I have created a ticket to do so.

ALMOST ALWAYS
- [ ] I added or updated documentation/README

SOMETIMES
- [ ] (If this PR ends in a 0) I have scheduled a team code review

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

[BMAPS-2448]: https://northpoint-development.atlassian.net/browse/BMAPS-2448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ